### PR TITLE
Exclude IntelliJ Settings from GIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ replay_pid*
 .settings/
 gradlew*
 test-output/
+
+.idea/


### PR DESCRIPTION
Excluding Intellij files so IntelliJ doesnt mark them as "unversioned"