### PR TITLE
Fix attack logic for single attack strategy

### DIFF
--- a/src/main/java/de/fhdw/aiwars/control/samples/SingleAttack.java
+++ b/src/main/java/de/fhdw/aiwars/control/samples/SingleAttack.java
@@ -22,7 +22,7 @@ public class SingleAttack implements Player {
                 }
                 final GameField actualTargetField = targetField.get();
                 if (
-                    actualTargetField.getPlayer() == playerId || actualTargetField.getAmount() > fromField.getAmount()
+                    actualTargetField.getPlayer() == playerId || actualTargetField.getAmount() >= fromField.getAmount()
                 ) {
                     continue;
                 }


### PR DESCRIPTION
A '>' at this point ensures that the player attacks with the same nunber of troops and wins, but cannot occupy the field.